### PR TITLE
Reflected XSS Prevention - Always escape HTML in messages

### DIFF
--- a/js/base.js
+++ b/js/base.js
@@ -187,6 +187,7 @@ var app = {
 		// show success, warning or error message
 		// Dialog.hide();
 		var icon = '';
+		msg = escape_text_field_value(msg); // escape any html chars
 		switch (type) {
 			case 'success': icon = 'check-circle'; break;
 			case 'warning': icon = 'exclamation-circle'; break;


### PR DESCRIPTION
A small reflected XSS vulnerability exists in Cronicle (and by extension, `pixl-webapp`) that allows a bad actor to trick a user into RCE within the user's browser if they clicked the below link. Amongst many other things, this RCE could then be used to send the target's `session_id` to a domain owned by the bad actor, allowing them to hijack the target's session.

This PR contains a fix so that all messages are fully escaped before being displayed on screen.

**Steps to reproduce:**
1. As a valid user of a default Cronicle v0.9.85 installation, navigate to `http://localhost:3012/#Schedule?sub=edit_event&id=em86antsr0kxxx%3Cimg%20src=1%20onerror=alert(localStorage.getItem(%22session_id%22))%3Exxxxx`
2. Observe that an alert is presented to the user containing their complete `session_id`.

<img width="1245" height="310" alt="image" src="https://github.com/user-attachments/assets/5e41edae-26a8-4497-a755-f404c692eb53" />

**Evidence of fix:**
<img width="1048" height="217" alt="image" src="https://github.com/user-attachments/assets/98c8aafb-0003-4eaf-8d85-5811d4487a42" />

